### PR TITLE
Don't replace configs

### DIFF
--- a/runme
+++ b/runme
@@ -298,15 +298,22 @@ sudo chown $PP_USER:$PP_USER /var/log/release-station.log
 sudo chown $PP_USER:$PP_USER $PP_HOME/release-station.log
 
 if [[ -z "$UPGRADE" ]] ; then
-
-  sudo tee  /boot/pc-connection.properties <<EOF
+    if [[ -f "/boot/pc-connection.properties" ]] ; then
+        echo "/boot/pc-connection.properties already present not overwriting"
+    else
+        sudo tee /boot/pc-connection.properties <<EOF
 server-ip=$SERVER_IP
 server-port=$SERVER_PORT
 server-name=$SERVER_NAME
 EOF
+    fi
 
-  sudo mv $PP_HOME/release/config.properties  /boot/pc-config.properties
-  # sudo mv $PP_HOME/release/client-machine-aliases.properties /boot/client-machine-aliases.properties
+    if [[ -f "/boot/pc-config.properties" ]] ; then
+        echo "/boot/pc-config.properties already present not overwriting"
+    else
+        sudo mv $PP_HOME/release/config.properties  /boot/pc-config.properties
+        # sudo mv $PP_HOME/release/client-machine-aliases.properties /boot/client-machine-aliases.properties
+    fi
 fi
 
 

--- a/runme
+++ b/runme
@@ -398,33 +398,35 @@ Section "ServerFlags"
 EndSection
 EOF
 
-echo We can put some host setttings in the /boot/machine.local and you can edit them on your laptop as needed
+if [[ -f "/boot/machine.local" ]] ; then
 
-echo
-echo Host name management
-echo ====================
-echo
-echo There are three options:
-echo "Keep the current hostname \"$(hostname)\""
-echo "Change to a fixed hostname of your choosing"
-echo "Have the Pi dynamically allocate a a hostname based on the CPU serial number at boot time"
-echo
-echo
+    echo We can put some host setttings in the /boot/machine.local and you can edit them on your laptop as needed
 
-dynhostname=$'rpi$(sed -nre \'/^Serial\t\t: ........(........)$/s//\\1/p\' /proc/cpuinfo)'
+    echo
+    echo Host name management
+    echo ====================
+    echo
+    echo There are three options:
+    echo "Keep the current hostname \"$(hostname)\""
+    echo "Change to a fixed hostname of your choosing"
+    echo "Have the Pi dynamically allocate a a hostname based on the CPU serial number at boot time"
+    echo
+    echo
 
-select selection in "Keep the current hostname \"$(hostname)\"" \
-                    "Provide a new hostname" \
-                    "CPU serial number based hostname" ; do
-    case "$REPLY" in
-        1) newhostname=$(hostname) ; break ;;
-        2) newhostname=$(ask "Please provide new hostname ") ; break ;;
-        3) newhostname=$'rpi$(sed -nre \'/^Serial\t\t: ........(........)$/s//\\1/p\' /proc/cpuinfo)' ; break;;
-        *) echo "$selection is invalid. Please select from list" ;;
-    esac
-done
+    dynhostname=$'rpi$(sed -nre \'/^Serial\t\t: ........(........)$/s//\\1/p\' /proc/cpuinfo)'
 
-sudo tee /boot/machine.local <<EOF
+    select selection in "Keep the current hostname \"$(hostname)\"" \
+                        "Provide a new hostname" \
+                        "CPU serial number based hostname" ; do
+        case "$REPLY" in
+            1) newhostname=$(hostname) ; break ;;
+            2) newhostname=$(ask "Please provide new hostname ") ; break ;;
+            3) newhostname=$'rpi$(sed -nre \'/^Serial\t\t: ........(........)$/s//\\1/p\' /proc/cpuinfo)' ; break;;
+            *) echo "$selection is invalid. Please select from list" ;;
+        esac
+    done
+
+    sudo tee /boot/machine.local <<EOF
 # Edit this file and reboot the Pi.
 # NB Insert the SD card into a workstation and you can edit the file as well
 
@@ -437,6 +439,8 @@ newhostname=$newhostname  # Host for /etc/host
 # TODO -- add example here.
 #
 EOF
+
+fi
 
 cat <<'EOF' | sudo tee /usr/local/sbin/config-hostname > /dev/null
 #!/bin/sh

--- a/runme
+++ b/runme
@@ -400,6 +400,10 @@ EOF
 
 if [[ -f "/boot/machine.local" ]] ; then
 
+    echo "/boot/machine.local already present not overwriting"
+
+else
+
     echo We can put some host setttings in the /boot/machine.local and you can edit them on your laptop as needed
 
     echo


### PR DESCRIPTION
If existing configs are present in the boot partition, placed during the writing of the SD card don't replace them with "default" ones.